### PR TITLE
Index one dir at a time

### DIFF
--- a/app/indexer/controllers.py
+++ b/app/indexer/controllers.py
@@ -82,6 +82,22 @@ def from_crawl():
     return progress_crawl(username=username)
 
 
+def run_indexing(username, url, title, snippet, description, lang, doc):
+    logging.debug("\t>>> INDEXER: CONTROLLER: PROGRESS CRAWL: INDEXING "+url)
+    new, idx = add_to_idx_to_url(username, url)
+    pod_name, _, tokenized_text = mk_page_vector.compute_vectors_local_docs( \
+        url, title, description, doc, username, lang)
+    if not new:
+        logging.info("\t>>> INDEXER: CONTROLLER: PROGRESS CRAWL: URL PREVIOUSLY KNOWN: "+url)
+        rm_doc_from_pos(idx, pod_name) #in case old version is there
+        vid = rm_from_npz_to_idx(pod_name, idx)
+        if vid != -1:
+            rm_from_npz(vid, pod_name)
+    posix_doc(tokenized_text, idx, pod_name, lang, username)
+    add_to_npz_to_idx(pod_name, idx)
+    create_or_replace_url_in_db(url, title, snippet, description, username, lang)
+
+
 @indexer.route("/progress_crawl")
 @login_required
 def progress_crawl(username=None):
@@ -89,49 +105,44 @@ def progress_crawl(username=None):
     Reads the start URL given by the user and
     recursively crawls down directories from there.
     """
-    print("Running progress crawl")
     if 'username' in session:
         username = session['username']
     # There will only be one path read, although we are using the standard
     # PeARS read_urls function. Hence the [0].
-    url = read_urls(join(user_app_dir_path, username+".toindex"))[0]
-    spider.write_docs(url, username) #Writing docs to corpus
+    start_url = read_urls(join(user_app_dir_path, username+".toindex"))[0]
+    print(f"Running progress crawl from {start_url}.")
 
     def generate():
         with app.app_context():
             print("\n\n>>> INDEXER: CONTROLLER: READING DOCS")
-            corpus = join(user_app_dir_path, username+".corpus")
-            urls, titles, snippets, descriptions, languages, docs = \
-                    read_docs(corpus)
-            if len(urls) == 0:
+            links = []
+            docs, urldir = spider.process_xml(start_url, username)
+            if len(docs) == 0:
                 yield "data:100\n\n"
 
             c = 0
             if tracker is not None:
-                task_name = "run indexing for "+str(len(urls))+" files"
+                task_name = "run indexing for "+str(len(docs))+" files"
                 tracker.start_task(task_name)
-            for url, title, snippet, description, lang, doc in \
-                    zip(urls, titles, snippets, descriptions, languages, docs):
-                logging.debug("\t>>> INDEXER: CONTROLLER: PROGRESS CRAWL: INDEXING "+url)
-                new, idx = add_to_idx_to_url(username, url)
-                pod_name, _, tokenized_text = mk_page_vector.compute_vectors_local_docs( \
-                    url, title, description, doc, username, lang)
-                if not new:
-                    logging.info("\t>>> INDEXER: CONTROLLER: PROGRESS CRAWL: URL PREVIOUSLY KNOWN: "+url)
-                    rm_doc_from_pos(idx, pod_name) #in case old version is there
-                    vid = rm_from_npz_to_idx(pod_name, idx)
-                    if vid != -1:
-                        rm_from_npz(vid, pod_name)
-                posix_doc(tokenized_text, idx, pod_name, lang, username)
-                add_to_npz_to_idx(pod_name, idx)
-                create_or_replace_url_in_db(url, title, snippet, description, username, lang)
+            for doc in docs:
+                url, process = spider.get_doc_url(doc, urldir)
+                if not process:
+                    continue
+                convertible = spider.assess_convertibility(doc)
+                content_type, islink = spider.get_doc_content_type(doc, url)
+                title = spider.get_doc_title(doc, url)
+                description = spider.get_doc_description(doc, title)
+                body_title, body_str, language = spider.get_doc_content(url, convertible, content_type)
+                if title is None:
+                    title = body_title
+                print(f"\n{url}, convertible: {convertible}, content_type: {content_type}, islink: {islink}, title: {title}, description: {description}, body_str: {body_str}, language: {language}\n")
+                run_indexing(username, url, title, body_str[:100], description, language, body_str)
+                if islink:
+                    links.append(url)
                 c += 1
-                #print('###', str(ceil(c / len(urls) * 100)))
-                yield "data:" + str(ceil(c / len(urls) * 100)) + "\n\n"
+                yield "data:" + str(ceil(c / len(docs) * 100)) + "\n\n"
             if tracker is not None:
                 search_emissions = tracker.stop_task()
                 carbon_print(search_emissions, task_name)
-            if isfile(join(user_app_dir_path, username+".corpus")):
-                remove(join(user_app_dir_path, username+".corpus"))
 
     return Response(generate(), mimetype='text/event-stream')

--- a/app/indexer/htmlparser.py
+++ b/app/indexer/htmlparser.py
@@ -121,7 +121,7 @@ def extract_txt(url):
     language = LANGS[0]
     logging.debug(f">> INDEXER: HTMLPARSER: extract_txt: title: {title}")
     try:
-        req = requests.get(url, timeout=10, headers={'Authorization': AUTH_TOKEN})
+        req = requests.get(url, timeout=120, headers={'Authorization': AUTH_TOKEN})
         req.encoding = 'utf-8'
     except Exception:
         return title, body_str, snippet, language

--- a/app/indexer/spider.py
+++ b/app/indexer/spider.py
@@ -42,7 +42,6 @@ def get_docs_from_xml_parse(parse):
         docs = parse['omd_index']['doc']
     except:
         logging.error(">> ERROR: SPIDER: get docs from xml parse: No documents found in the XML.")
-    print(docs)
     return docs
 
 
@@ -177,45 +176,3 @@ def get_doc_content(url, convertible, content_type):
 
     return title, body_str, language
 
-
-
-
-
-
-def write_docs(base_url, username):
-    """Write document corpus while crawling.
-    Argument: base url, to start the crawl from.
-    """
-    if base_url is None:
-        print("No url passed.")
-        return url_for('indexer')
-
-    if not LOCAL_RUN and base_url[-1] != '/':
-        base_url+='/'
-
-    pages_to_visit = [base_url]
-    pages_visited = []
-    corpus_path = join(user_app_dir_path, username+'.corpus')
-
-    #Initialise user's corpus path
-    fout = open(corpus_path,'w', encoding="utf-8")
-    fout.close()
-
-    print(">> INDEXER: SPIDER: write_docs: Starting crawl from",base_url)
-    while len(pages_to_visit) > 0:
-        # Start from base url
-        #print("Pages to visit",pages_to_visit)
-        url = pages_to_visit[0]
-        pages_visited.append(url)
-        try:    
-            links = omd_parse(url, username)
-            for link in links:
-                #print(link,pages_visited)
-                #print(link,pages_to_visit)
-                #print(link,urldir)
-                if link not in pages_visited and link not in pages_to_visit and '#' not in link:
-                    #print("Found href:",link)
-                    pages_to_visit.append(link)
-        except: 
-            print(f">> ERROR: SPIDER: OMD PARSE: exceptions in parsing: {url}")
-        pages_to_visit = pages_to_visit[1:]


### PR DESCRIPTION
This PR avoids the creation of temporary files during the indexing process and indexes one folder at a time, ensuring that interrupted processes still result in partial indexing.