### PR TITLE
Fix #11: remove hardcoded references to 'localhost:9090'

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -21,6 +21,9 @@ from flask_sqlalchemy import SQLAlchemy
 # Root path
 dir_path = dirname(dirname(realpath(__file__)))
 
+# Server host
+SERVER_HOST = "localhost:9090"
+
 # Initialise emission tracking
 CARBON_TRACKING = False
 CARBON_DIR = None

--- a/app/search/controllers.py
+++ b/app/search/controllers.py
@@ -14,7 +14,7 @@ from app import app
 from app.utils import get_language, beautify_snippet, beautify_title
 from app.search.score_pages import run_search
 from app.auth.controllers import login_required
-from app import LOCAL_RUN, OMD_PATH, LANGS
+from app import LOCAL_RUN, SERVER_HOST, OMD_PATH, LANGS
 
 LOG = logging.getLogger(__name__)
 
@@ -83,7 +83,7 @@ def run_user_search(query):
     else:
         languages = [lang]
     for lang in languages:
-        r, s = run_search(query+' -'+lang, url_filter=[join(url,username), join(url,'shared'), 'http://localhost:9090/'])
+        r, s = run_search(query+' -'+lang, url_filter=[join(url,username), join(url,'shared'), f'http://{SERVER_HOST}/'])
         for k,v in r.items():
             if v is not None:
                 i = list(r.keys()).index(k)
@@ -98,7 +98,7 @@ def run_user_search(query):
 
 def run_anonymous_search(query):
     if LOCAL_RUN:
-        url = 'http://localhost:9090/testdocs/shared' #Local test
+        url = f'http://{SERVER_HOST}/testdocs/shared' #Local test
     else:
         url = join(OMD_PATH, 'shared')
     results = {}

--- a/app/utils_db.py
+++ b/app/utils_db.py
@@ -7,7 +7,7 @@ import joblib
 from os.path import dirname, realpath, join, isfile, isdir
 import os
 from app import db, models
-from app import LOCAL_RUN, OMD_PATH, LANGS, VEC_SIZE
+from app import LOCAL_RUN, OMD_PATH, LANGS, VEC_SIZE, SERVER_HOST
 from app.api.models import Urls, Pods
 from app.api.models import installed_languages
 from app.indexer.posix import load_posix, dump_posix
@@ -24,7 +24,7 @@ def get_pod_name(target_url, lang, username, device):
     """
     pod_name = f"{username}/{device}/{lang}/private"
     if LOCAL_RUN:
-        if 'http://localhost:9090/testdocs/shared' in target_url:
+        if f'http://{SERVER_HOST}/testdocs/shared' in target_url:
             pod_name = f"{username}/{device}/{lang}/shared"
     else:
         if join(OMD_PATH, 'shared') in target_url:

--- a/run.py
+++ b/run.py
@@ -5,5 +5,8 @@
 # Run a test server.
 
 from app import app
+from app import SERVER_HOST
 
-app.run(host='0.0.0.0', port=9090, debug=True, threaded=True)
+
+host, port = SERVER_HOST.split(":")
+app.run(host=host, port=int(port), debug=True, threaded=True)


### PR DESCRIPTION
There seem to be no other hardcoded port references in the code base at the moment (apart from #9). This pr makes 'localhost:9090' a global variable, so that it doesn't need to be hard coded at various points in the code. In the future, we could consider making this a config variable instead of a (hardcoded) global variable. 